### PR TITLE
11 add nested directory structure for reco subdirectories to website

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Search the database and save the file names as a list
       shell: bash
       run: |
+        rm -R .docs/_data/LOG/
         mc config host add S3 ${S3_HOST} ${S3_ACCESS_KEY} ${S3_SECRET_KEY}
         chmod +x ./docs/_data/list_S3.sh
         ./docs/_data/list_S3.sh > ./docs/_data/s3_content.yml
@@ -49,9 +50,9 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add ./docs/_data/s3_content.yml
+        git add ./docs/_data/
         git commit -m "Update list in s3_content.yml" || echo "No changes to commit"
-        git push origin website
+        git push origin main
 
 #  github-pages:
 #    runs-on: ubuntu-latest

--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -6,8 +6,8 @@ OBJECTS=$(mc ls S3/eictest/EPIC/LOG)
 # Iterate over the objects: print their names and create folders in the repository containing index.md
 while IFS= read -r object; do
   name_only= $object | sed -n 's/^\[[^][]*][[:blank:]]*[^[:blank:]]*[[:blank:]]*\(.*\)$/\1/p' # extracts the folder name from mc ls
-  mkdir -p ./docs/_data/LOG/"$name_only"
-  touch ./docs/_data/LOG/"$name_only"index.md
-  mc tree S3/eictest/EPIC/LOG/"$name_only" > ./docs/_data/LOG/"$name_only"index.md
+  mkdir -p ./docs/_data/LOG/"${name_only}"
+  touch ./docs/_data/LOG/"${name_only}"index.md
+  mc tree S3/eictest/EPIC/LOG/"${name_only}" > ./docs/_data/LOG/"${name_only}"index.md
   echo -e "- text: "$object"\n  url: "/$name_only""
 done <<< "$OBJECTS"

--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# List all objects in the S3 bucket
-OBJECTS=$(mc ls --recursive  S3/eictest/EPIC/EVGEN)
+# List all objects in the S3 LOG directory
+OBJECTS=$(mc ls S3/eictest/EPIC/LOG)
 
-# Iterate over the objects and print their names
+# Iterate over the objects: print their names and create folders in the repository containing index.md
 while IFS= read -r object; do
-  name_only=$(echo "$object" | grep -oP 'STANDARD \K.*')
-  echo "- $name_only"
+  name_only= $object | sed -n 's/^\[[^][]*][[:blank:]]*[^[:blank:]]*[[:blank:]]*\(.*\)$/\1/p' # extracts the folder name from mc ls
+  mkdir -p ./docs/_data/LOG/"$name_only"
+  touch ./docs/_data/LOG/"$name_only"index.md
+  mc tree S3/eictest/EPIC/LOG/"$name_only" > ./docs/_data/LOG/"$name_only"index.md
+  echo -e "- text: "$object"\n  url: "/$name_only""
 done <<< "$OBJECTS"

--- a/docs/_layouts/campaigns.html
+++ b/docs/_layouts/campaigns.html
@@ -3,6 +3,6 @@ layout: default
 ---
 <ul>
 {% for line in site.data.s3_content %}
-  <li>{{ line }}</li>
+  <li><a href="{{ line.url }}">{{ line.text }}</a></li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the campaigns page to list the subdirectories of S3/eictest/EPIC/LOG/, which are themselves hyperlinks to tree diagrams depicting the further subdirectories. The data for this is stored in the repository under docs/_data/LOG/ .

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #11 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
The campaigns page no longer displays the files from the EVGEN folder in S3.