### PR TITLE
Added command substitution to fix name extraction error

### DIFF
--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -5,7 +5,7 @@ OBJECTS=$(mc ls S3/eictest/EPIC/LOG)
 
 # Iterate over the objects: print their names and create folders in the repository containing index.md
 while IFS= read -r object; do
-  name_only= $object | sed -n 's/^\[[^][]*][[:blank:]]*[^[:blank:]]*[[:blank:]]*\(.*\)$/\1/p' # extracts the folder name from mc ls
+  name_only=$(echo "$object" | sed -n 's/^\[[^][]*][[:blank:]]*[^[:blank:]]*[[:blank:]]*\(.*\)$/\1/p') # extracts the folder name from mc ls
   mkdir -p ./docs/_data/LOG/"${name_only}"
   touch ./docs/_data/LOG/"${name_only}"index.md
   mc tree S3/eictest/EPIC/LOG/"${name_only}" > ./docs/_data/LOG/"${name_only}"index.md


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the error in list_S3.sh to extract the folder name from the output of `mc ls S3/eictest/EPIC/LOG` by properly using command substitution.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #20 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
