### PR TITLE
Updated nightly-updates.yml to commit changes to LOG/ directory

### DIFF
--- a/.github/workflows/nightly-updates.yml
+++ b/.github/workflows/nightly-updates.yml
@@ -29,6 +29,11 @@ jobs:
       with:
         name: s3_content
         path: ./docs/_data/s3_content.yml
+    - name: Upload LOG
+      uses: actions/upload-artifact@v3
+      with:
+        name: LOG
+        path: ./docs/_data/LOG/
         
   commit_data:
     needs: update_data
@@ -40,16 +45,22 @@ jobs:
       shell: bash
       run: |
         rm ./docs/_data/s3_content.yml
+        rm -R ./docs/_data/LOG/
     - name: Download s3_content
       uses: actions/download-artifact@v3
       with:
         name: s3_content
         path: ./docs/_data/
-    - name: Commit s3_content.yml
+    - name: Download LOG
+      uses: actions/download-artifact@v3
+      with:
+        name: LOG
+        path: ./docs/_data/
+    - name: Commit updates
       shell: bash
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add ./docs/_data/
-        git commit -m "Update list in s3_content.yml" || echo "No changes to commit"
+        git commit -m "Update list in s3_content.yml and LOG/ directory" || echo "No changes to commit"
         git push origin main


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The nightly-updates.yml workflow now updates the docs/_data/LOG/ directory in this repository. Previously, it was not passing the updated LOG/ through the workflow to commit the updates.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #29 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
