### PR TITLE
Added `/epic-prod` to the url generator in list_S3.sh

### DIFF
--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -9,5 +9,5 @@ while IFS= read -r object; do
   mkdir -p ./docs/LOG/"${name_only}"
   touch ./docs/LOG/"${name_only}"index.md
   mc tree S3/eictest/EPIC/LOG/"${name_only}" > ./docs/LOG/"${name_only}"index.md
-  echo -e "- text: "$name_only"\n  url: "/LOG/$name_only""
+  echo -e "- text: "$name_only"\n  url: "/epic-prod/LOG/$name_only""
 done <<< "$OBJECTS"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR aims to fix issue #37 by updating the url generator in list_S3.sh to include `/epic-prod` at the start of each url field.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #37 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
