### PR TITLE
Added code block indicators to the start and end of every index.md

### DIFF
--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -8,6 +8,8 @@ while IFS= read -r object; do
   name_only=$(echo "$object" | sed -n 's/^\[[^][]*][[:blank:]]*[^[:blank:]]*[[:blank:]]*\(.*\)$/\1/p') # extracts the folder name from mc ls
   mkdir -p ./docs/LOG/"${name_only}"
   touch ./docs/LOG/"${name_only}"index.md
-  mc tree S3/eictest/EPIC/LOG/"${name_only}" > ./docs/LOG/"${name_only}"index.md
+  echo '```' > ./docs/LOG/"${name_only}"index.md
+  mc tree S3/eictest/EPIC/LOG/"${name_only}" >> ./docs/LOG/"${name_only}"index.md
+  echo '```' >> ./docs/LOG/"${name_only}"index.md
   echo -e "- text: "$name_only"\n  url: "/epic-prod/LOG/$name_only""
 done <<< "$OBJECTS"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes issue #39 by adding code block indicators to each index.md file when they're being constructed. This will make the tree diagrams formatted correctly on the campaign webpages.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #39 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
