### PR TITLE
Added counting of files to tree diagram construction

### DIFF
--- a/docs/_data/list_S3.sh
+++ b/docs/_data/list_S3.sh
@@ -9,7 +9,7 @@ while IFS= read -r object; do
   mkdir -p ./docs/LOG/"${name_only}"
   touch ./docs/LOG/"${name_only}"index.md
   echo '```' > ./docs/LOG/"${name_only}"index.md
-  mc tree S3/eictest/EPIC/LOG/"${name_only}" >> ./docs/LOG/"${name_only}"index.md
+  mc tree --files S3/eictest/EPIC/LOG/"${name_only}" | sed 's/.*\.root$//g' | uniq -c | sed 's/.*1 //' >> ./docs/LOG/"${name_only}"index.md # contructs tree diagram with count of files in each directory
   echo '```' >> ./docs/LOG/"${name_only}"index.md
   echo -e "- text: "$name_only"\n  url: "/epic-prod/LOG/$name_only""
 done <<< "$OBJECTS"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the tree diagram script to also display a count of the files within each directory.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #41)
- [ ] Documentation update
- [ ] Other: __

This PR will adjust the tree diagrams to appear like the attached image.
![tree with count](https://github.com/eic/epic-prod/assets/76755531/882f7ba5-e4c4-4f0b-ae9e-e8351aaf510d)
