### PR TITLE
Switch source for RECO list from work disk to volatile

### DIFF
--- a/.github/workflows/nightly-updates.yml
+++ b/.github/workflows/nightly-updates.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  RECO: "/work/eic2/EPIC/RECO"
+  RECO: "/volatile/eic/EPIC/RECO"
   FULL: "/work/eic2/EPIC/FULL"
   XROOTD_HOST: root://dtn-eic.jlab.org
   REPOSITORY: "${{github.repository}}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Switch source for RECO list from work disk to volatile

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. For the time being, the older campaign summaries before 25.01.1 will not show.

### Does this PR change default behavior?
