### PR TITLE
Rename 'Generator Config' to 'Generator/Dataset Version'

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset_request.yml
+++ b/.github/ISSUE_TEMPLATE/dataset_request.yml
@@ -29,11 +29,11 @@ body:
       required: false
 
   - type: input
-    id: generator_config
+    id: generator_dataset_version
     attributes:
-      label: Generator Config
-      description: Event generator name and version (e.g. Pythia8, EpIC, BeAGLE 1.03.02)
-      placeholder: "e.g. EpIC, Pythia 8.306, BeAGLE 1.03.02"
+      label: Generator/Dataset Version
+      description: Please provide a link to the tagged release of the generator/dataset repository (e.g. https://github.com/org/repo/releases/tag/v1.0)
+      placeholder: "e.g. https://github.com/org/repo/releases/tag/v1.0"
     validations:
       required: false
 

--- a/.github/workflows/append_dataset.yml
+++ b/.github/workflows/append_dataset.yml
@@ -48,7 +48,7 @@ jobs:
           row = [
               clean(raw.get("dsc_or_pwg", "")),
               clean(raw.get("dataset_path", "")),
-              clean(raw.get("generator_config", "")),
+              clean(raw.get("generator_dataset_version", "")),
               clean(raw.get("number_of_events", "")) or "All",
               clean(raw.get("background", "")),
               clean(raw.get("new_request", "")),

--- a/docs/_data/datasets.csv
+++ b/docs/_data/datasets.csv
@@ -1,4 +1,4 @@
-DSC or PWG,Dataset Path,Generator Config,Number of Events,Background,New Request,Pre-TDR Use,Early Science Use,Other Use,Description,Priority
+DSC or PWG,Dataset Path,Generator/Dataset Version,Number of Events,Background,New Request,Pre-TDR Use,Early Science Use,Other Use,Description,Priority
 Exclusive/Diffractive/Tagging,Input Files: /w/eic-scshelf2104/users/sjdkay/Jul2025_Campaign_Input/Afterburner_Output/pion,DEMPgen1.2.4,2.4M,No,No,Maybe,Yes,Potential ZDC performance studies,"DEMP events for pion and kaon structure studies. Two configurations, ep 10x130 and 10x250, for early science impact studies. New version of event generator that utilises a restrcited -t range to boost statistics in the crucial (for FPi studies) low t region. ",1
 Exclusive/Diffractive/Tagging,"/w/eic-scshelf2104/users/
 gbxalex/SimCampaign_Input",lAger3.6.1,2.75M,No,Yes,No,Yes,Muon ID studies,"DVMP events for J/Psi studies. For the 10x130 configuration, 

--- a/docs/_documentation/default_datasets.md
+++ b/docs/_documentation/default_datasets.md
@@ -16,7 +16,7 @@ It tracks both completed and pending requests to aid planning and prioritisation
     <tr>
       <th>DSC or PWG</th>
       <th>Dataset Path</th>
-      <th>Generator Config</th>
+      <th>Generator/Dataset Version</th>
       <th>Number of Events</th>
       <th>Background</th>
       <th>New Request</th>
@@ -33,7 +33,7 @@ It tracks both completed and pending requests to aid planning and prioritisation
       <tr>
         <td>{{ row["DSC or PWG"] }}</td>
         <td>{{ row["Dataset Path"] }}</td>
-        <td>{{ row["Generator Config"] }}</td>
+        <td>{{ row["Generator/Dataset Version"] }}</td>
         <td>{{ row["Number of Events"] }}</td>
         <td>{{ row["Background"] }}</td>
         <td>{{ row["New Request"] }}</td>


### PR DESCRIPTION
Updates column name across CSV header, Jekyll table, issue form field label and id, and workflow parser key.


Rename 'Generator Config' to 'Generator/Dataset Version'