### PR TITLE
Add correction-comment mechanism for dataset requests

### DIFF
--- a/.github/workflows/append_dataset.yml
+++ b/.github/workflows/append_dataset.yml
@@ -33,6 +33,7 @@ jobs:
         shell: python3 {0}
         env:
           PARSED_JSON: ${{ steps.issue_parser.outputs.jsonString }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           import csv, json, os, re
 
@@ -57,6 +58,7 @@ jobs:
               clean(raw.get("other_use", "")),
               clean(raw.get("description", "")),
               priority_num(raw.get("priority", "")),
+              os.environ["ISSUE_NUMBER"],
           ]
 
           csv_path = "docs/_data/datasets.csv"

--- a/.github/workflows/correct_dataset.yml
+++ b/.github/workflows/correct_dataset.yml
@@ -1,0 +1,124 @@
+name: Correct Dataset Request
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: append-dataset
+  cancel-in-progress: false
+
+jobs:
+  correct-dataset:
+    if: |
+      startsWith(github.event.comment.body, '!update') &&
+      contains(github.event.issue.labels.*.name, 'dataset-request')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: dataset-request/issue-${{ github.event.issue.number }}
+
+      - name: Apply correction to CSV
+        id: correction
+        shell: python3 {0}
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          import csv, io, os, re, sys
+
+          comment = os.environ["COMMENT"].strip()
+          issue_number = os.environ["ISSUE_NUMBER"]
+
+          # Parse: !update Field Name: new value
+          m = re.match(r'^!update\s+(.+?):\s*(.+)$', comment, re.DOTALL)
+          if not m:
+              print("ERROR: Could not parse correction comment.")
+              print("Expected format: !update Field Name: new value")
+              sys.exit(1)
+
+          field_name = m.group(1).strip()
+          new_value = m.group(2).strip()
+
+          csv_path = "docs/_data/datasets.csv"
+          with open(csv_path, newline="") as f:
+              reader = csv.DictReader(f)
+              rows = list(reader)
+              fieldnames = list(reader.fieldnames)
+
+          # Validate field name
+          if field_name not in fieldnames:
+              print(f"ERROR: Unknown field '{field_name}'")
+              print(f"Valid fields: {', '.join(fieldnames)}")
+              sys.exit(1)
+
+          # Find the row for this issue
+          target_idx = None
+          for i, row in enumerate(rows):
+              if row.get("Issue", "").strip() == issue_number:
+                  target_idx = i
+                  break
+
+          if target_idx is None:
+              print(f"ERROR: No CSV row found for issue #{issue_number}")
+              sys.exit(1)
+
+          old_value = rows[target_idx][field_name]
+          rows[target_idx][field_name] = new_value
+
+          # Write back
+          out = io.StringIO()
+          writer = csv.DictWriter(out, fieldnames=fieldnames, quoting=csv.QUOTE_MINIMAL)
+          writer.writeheader()
+          writer.writerows(rows)
+
+          with open(csv_path, "w", newline="") as f:
+              f.write(out.getvalue())
+
+          print(f"Updated '{field_name}': '{old_value}' -> '{new_value}'")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"field_name={field_name}\n")
+              f.write(f"old_value={old_value}\n")
+              f.write(f"new_value={new_value}\n")
+
+      - name: Commit correction
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add docs/_data/datasets.csv
+          git commit -m "Correct dataset request #${{ github.event.issue.number }}: update ${{ steps.correction.outputs.field_name }}"
+          git pull --rebase origin dataset-request/issue-${{ github.event.issue.number }}
+          git push origin dataset-request/issue-${{ github.event.issue.number }}
+
+      - name: Comment confirmation
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Correction applied to the open PR:\n\n**${{ steps.correction.outputs.field_name }}**: ~~${{ steps.correction.outputs.old_value }}~~ → \`${{ steps.correction.outputs.new_value }}\``
+            });
+
+      - name: Comment on error
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Could not apply correction. Please check the format:\n\n\`\`\`\n!update Field Name: new value\n\`\`\`\n\nValid field names: DSC or PWG, Dataset Path, Generator/Dataset Version, Number of Events, Background, New Request, Pre-TDR Use, Early Science Use, Other Use, Description, Priority`
+            });

--- a/docs/_data/datasets.csv
+++ b/docs/_data/datasets.csv
@@ -1,4 +1,4 @@
-DSC or PWG,Dataset Path,Generator/Dataset Version,Number of Events,Background,New Request,Pre-TDR Use,Early Science Use,Other Use,Description,Priority
+DSC or PWG,Dataset Path,Generator/Dataset Version,Number of Events,Background,New Request,Pre-TDR Use,Early Science Use,Other Use,Description,Priority,Issue
 Exclusive/Diffractive/Tagging,Input Files: /w/eic-scshelf2104/users/sjdkay/Jul2025_Campaign_Input/Afterburner_Output/pion,DEMPgen1.2.4,2.4M,No,No,Maybe,Yes,Potential ZDC performance studies,"DEMP events for pion and kaon structure studies. Two configurations, ep 10x130 and 10x250, for early science impact studies. New version of event generator that utilises a restrcited -t range to boost statistics in the crucial (for FPi studies) low t region. ",1
 Exclusive/Diffractive/Tagging,"/w/eic-scshelf2104/users/
 gbxalex/SimCampaign_Input",lAger3.6.1,2.75M,No,Yes,No,Yes,Muon ID studies,"DVMP events for J/Psi studies. For the 10x130 configuration, 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
- Add 'Issue' column to docs/_data/datasets.csv header to track which row belongs to which GitHub issue (not rendered in the Jekyll table)
- Update append_dataset.yml to write the issue number as the last CSV field so corrections can locate the correct row
- Add correct_dataset.yml workflow triggered by !update comments on dataset-request issues; parses 'Field Name: value', updates the row on the existing PR branch, and posts a confirmation comment

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
