### PR TITLE
Fix NoneType error when reading CSV fieldnames in correct_dataset

### DIFF
--- a/.github/workflows/correct_dataset.yml
+++ b/.github/workflows/correct_dataset.yml
@@ -51,8 +51,9 @@ jobs:
           csv_path = "docs/_data/datasets.csv"
           with open(csv_path, newline="") as f:
               reader = csv.DictReader(f)
+              fieldnames = reader.fieldnames
               rows = list(reader)
-              fieldnames = list(reader.fieldnames)
+              fieldnames = list(fieldnames)
 
           # Validate field name
           if field_name not in fieldnames:


### PR DESCRIPTION
reader.fieldnames must be captured before list(reader) exhausts the DictReader, otherwise it returns None on some Python/csv versions.

