### PR TITLE
Fix/correct dataset fieldnames none

### DIFF
--- a/.github/workflows/correct_dataset.yml
+++ b/.github/workflows/correct_dataset.yml
@@ -51,8 +51,9 @@ jobs:
           csv_path = "docs/_data/datasets.csv"
           with open(csv_path, newline="") as f:
               reader = csv.DictReader(f)
+              fieldnames = reader.fieldnames
               rows = list(reader)
-              fieldnames = list(reader.fieldnames)
+              fieldnames = list(fieldnames)
 
           # Validate field name
           if field_name not in fieldnames:

--- a/.github/workflows/correct_dataset.yml
+++ b/.github/workflows/correct_dataset.yml
@@ -64,7 +64,7 @@ jobs:
           # Find the row for this issue
           target_idx = None
           for i, row in enumerate(rows):
-              if row.get("Issue", "").strip() == issue_number:
+              if (row.get("Issue") or "").strip() == issue_number:
                   target_idx = i
                   break
 


### PR DESCRIPTION
Fix/correct dataset fieldnames none

 row.get("Issue") returns None for rows missing the Issue column. row.get("Issue", "") looks like it should
  return "" as a default, but DictReader explicitly sets missing trailing fields to None — it doesn't leave
  the key absent, so the default argument to .get() is never used.

  (row.get("Issue") or "") works around this: None or "" evaluates to "", so .strip() is called on "" instead
  of None.

  This just makes the old pre-Issue rows safely skip past the match check (since "" won't equal any issue
  number), so the script can find the correct row without crashing.